### PR TITLE
Feat: 이력서 전체보기를 메인화 및 세부 기능 추가

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,6 +18,7 @@
         "moment": "^2.30.1",
         "pinia": "^2.2.6",
         "pinia-plugin-persistedstate": "^4.2.0",
+        "primevue": "^4.2.5",
         "vue": "^3.5.13",
         "vue-router": "^4.4.5"
       },
@@ -1227,6 +1228,56 @@
       "integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@primeuix/styled": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/styled/-/styled-0.3.2.tgz",
+      "integrity": "sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/utils": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primeuix/utils": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@primeuix/utils/-/utils-0.3.2.tgz",
+      "integrity": "sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.11.0"
+      }
+    },
+    "node_modules/@primevue/core": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@primevue/core/-/core-4.2.5.tgz",
+      "integrity": "sha512-+oWBIQs5dLd2Ini4KEVOlvPILk989EHAskiFS3R/dz3jeOllJDMZFcSp8V9ddV0R3yDaPdLVkfHm2Q5t42kU2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/styled": "^0.3.2",
+        "@primeuix/utils": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.0"
+      }
+    },
+    "node_modules/@primevue/icons": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@primevue/icons/-/icons-4.2.5.tgz",
+      "integrity": "sha512-WFbUMZhQkXf/KmwcytkjGVeJ9aGEDXjP3uweOjQZMmRdEIxFnqYYpd90wE90JE1teZn3+TVnT4ZT7ejGyEXnFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/utils": "^0.3.2",
+        "@primevue/core": "4.2.5"
+      },
+      "engines": {
+        "node": ">=12.11.0"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
@@ -3864,6 +3915,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/primevue": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-4.2.5.tgz",
+      "integrity": "sha512-7UMOIJvdFz4jQyhC76yhNdSlHtXvVpmE2JSo2ndUTBWjWJOkYyT562rQ4ayO+bMdJLtzBGqgY64I9ZfEvNd7vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@primeuix/styled": "^0.3.2",
+        "@primeuix/utils": "^0.3.2",
+        "@primevue/core": "4.2.5",
+        "@primevue/icons": "4.2.5"
+      },
+      "engines": {
+        "node": ">=12.11.0"
       }
     },
     "node_modules/proxy-from-env": {

--- a/front/package.json
+++ b/front/package.json
@@ -19,6 +19,7 @@
     "moment": "^2.30.1",
     "pinia": "^2.2.6",
     "pinia-plugin-persistedstate": "^4.2.0",
+    "primevue": "^4.2.5",
     "vue": "^3.5.13",
     "vue-router": "^4.4.5"
   },

--- a/front/src/components/Main/Footer.vue
+++ b/front/src/components/Main/Footer.vue
@@ -9,7 +9,7 @@
         <div>
           <h4 class="text-lg font-bold mb-4">서비스</h4>
           <ul class="space-y-2">
-            <li><router-link to="/resume" class="text-gray-400 hover:text-white transition-colors">이력서</router-link></li>
+            <li><router-link to="/resume-preview" class="text-gray-400 hover:text-white transition-colors">이력서</router-link></li>
             <li><router-link to="/cover-letter" class="text-gray-400 hover:text-white transition-colors">자기소개서 작성</router-link></li>
             <li><router-link to="/board" class="text-gray-400 hover:text-white transition-colors">자기소개서 목록</router-link></li>
             <li><router-link to="/mydata" class="text-gray-400 hover:text-white transition-colors">채용달력</router-link></li>

--- a/front/src/components/Main/Header.vue
+++ b/front/src/components/Main/Header.vue
@@ -73,7 +73,7 @@ const navigateToAuth = (isSignUp) => {
 const getRouteForItem = (item) => {
   switch (item) {
     case "이력서":
-      return "/resume";
+      return "/resume-preview";
     case "홈":
       return "/";
     case "자기소개서 작성":

--- a/front/src/components/Main/Hero.vue
+++ b/front/src/components/Main/Hero.vue
@@ -51,7 +51,7 @@ const slides = [
     title: "전문적인 이력서를 작성하세요",
     description: "당신의 경력을 돋보이게 만들어 줄 맞춤형 이력서 템플릿",
     buttonText: "이력서 작성하기",
-    action: "/resume",
+    action: "/resume-preview",
   },
   {
     id: 2,

--- a/front/src/router/index.js
+++ b/front/src/router/index.js
@@ -7,6 +7,7 @@ import ResumeView from '@/views/ResumeView.vue'
 import FAQView from '@/views/FAQView.vue'
 import AuthView from '@/views/AuthView.vue'
 import CoverLetterBoardView from '@/views/CoverLetterBoardView.vue'
+import ResumePreviewView from '@/views/ResumePreviewView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -46,6 +47,11 @@ const router = createRouter({
       name: 'CoverLetterBoard',
       component: CoverLetterBoardView
     },
+    {
+      path: "/resume-preview",
+      name: "ResumePreview",
+      component: ResumePreviewView,
+    }    
   ],
 })
 

--- a/front/src/views/ResumePreviewView.vue
+++ b/front/src/views/ResumePreviewView.vue
@@ -1,0 +1,181 @@
+<template>
+  <div class="container mx-auto px-4 sm:px-6 lg:px-8">
+    <div
+      class="max-w-4xl mx-auto bg-white shadow-md rounded-lg p-8 relative"
+      @click="openModal"
+    >
+      <!-- Overlay to block interactions -->
+      <div
+        class="absolute inset-0 bg-transparent cursor-pointer"
+        style="pointer-events: auto"
+      ></div>
+
+      <!-- Header -->
+      <header class="text-center mb-8">
+        <h1 class="text-4xl font-bold text-[#006B40]">이력서</h1>
+        <p class="text-gray-600">작성된 이력서를 확인하세요</p>
+      </header>
+
+      <!-- Personal Information -->
+      <div class="mb-12">
+        <h2 class="text-2xl font-bold text-[#006B40] mb-4">인적사항</h2>
+        <PersonalInfo :data="resumeData.personalInfo" />
+      </div>
+
+      <!-- Resume Sections -->
+      <div v-for="section in resumeSections" :key="section.id" class="mb-12">
+        <h3 class="text-xl font-bold text-[#006B40] mb-4">
+          {{ section.name }}
+        </h3>
+        <component
+          :is="getSectionComponent(section.id)"
+          :data="resumeData[section.id]"
+        />
+      </div>
+    </div>
+
+    <!-- Modal -->
+    <div
+      v-if="isModalOpen"
+      class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+    >
+      <div class="bg-white rounded-lg shadow-lg p-6 w-full max-w-md">
+        <p class="text-lg font-semibold text-gray-800 mb-4">
+          이력서 수정을 하시겠습니까?
+        </p>
+        <div class="flex justify-end space-x-4">
+          <button
+            @click="goToResumeEdit"
+            class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+          >
+            이력서 수정
+          </button>
+          <button
+            @click="closeModal"
+            class="px-4 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400"
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import { useRouter } from "vue-router";
+import { computed } from "vue";
+import { useResumeStore } from "@/stores/resume";
+
+// 컴포넌트 import
+import PersonalInfo from "@/components/Resume/PersonalInfo.vue";
+import Skills from "@/components/Resume/Skills.vue";
+import AcademicAbility from "@/components/Resume/AcademicAbility.vue";
+import Experience from "@/components/Resume/Experience.vue";
+import InternExtraActivities from "@/components/Resume/InternExtraActivities.vue";
+import Educations from "@/components/Resume/Educations.vue";
+import Certifications from "@/components/Resume/Certifications.vue";
+import Portfolio from "@/components/Resume/Portfolio.vue";
+import Awards from "@/components/Resume/Awards.vue";
+
+// Vuex Store에서 데이터 가져오기
+const resumeStore = useResumeStore();
+const resumeData = computed(() => resumeStore.resumeData);
+
+// 각 섹션 정의
+const resumeSections = [
+  { id: "skills", name: "스킬" },
+  { id: "educations", name: "학력" },
+  { id: "workExperiences", name: "경력" },
+  { id: "activities", name: "인턴 및 대외 활동" },
+  { id: "trainings", name: "교육 이수" },
+  { id: "certifications", name: "자격증" },
+  { id: "awards", name: "수상 내역" },
+  { id: "portfolios", name: "포트폴리오" },
+];
+
+// 섹션 ID에 따라 적절한 컴포넌트를 반환
+const getSectionComponent = (sectionId) => {
+  const components = {
+    skills: Skills,
+    educations: AcademicAbility,
+    workExperiences: Experience,
+    activities: InternExtraActivities,
+    trainings: Educations,
+    certifications: Certifications,
+    awards: Awards,
+    portfolios: Portfolio,
+  };
+  return components[sectionId];
+};
+
+// 모달 상태 관리
+const isModalOpen = ref(false);
+const router = useRouter();
+
+// 모달 열기
+const openModal = () => {
+  isModalOpen.value = true;
+};
+
+// 모달 닫기
+const closeModal = () => {
+  isModalOpen.value = false;
+};
+
+// 이력서 수정 페이지로 이동
+const goToResumeEdit = () => {
+  closeModal();
+  router.push("/resume");
+};
+</script>
+
+<style scoped>
+.container {
+  max-width: 800px;
+}
+
+header h1 {
+  margin-bottom: 0.5rem;
+}
+
+header p {
+  color: #4a5568; /* Tailwind gray-600 */
+}
+
+h2,
+h3 {
+  border-bottom: 2px solid #006b40;
+  padding-bottom: 0.5rem;
+}
+
+/* 추가 스타일 */
+.relative {
+  position: relative;
+}
+
+.absolute {
+  position: absolute;
+}
+
+.inset-0 {
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+/* 모달 스타일 */
+.fixed {
+  position: fixed;
+}
+
+.z-50 {
+  z-index: 50;
+}
+
+.bg-opacity-50 {
+  background-color: rgba(0, 0, 0, 0.5);
+}
+</style>


### PR DESCRIPTION
# 주요 변경 사항
## 상호작용 차단:
- pointer-events 속성을 활용하여 상위 요소가 모든 사용자 이벤트를 가로채도록 설정했습니다.
- .absolute.inset-0를 사용해 max-w-4xl 박스 위에 투명한 오버레이를 추가했습니다.
## 클릭 이벤트 처리:
- @click 이벤트를 max-w-4xl 컨테이너에 추가했습니다.
- 클릭 시 alert("이력서 수정을 하시겠습니까?") 경고창이 뜨도록 설정했습니다.
## CSS 구조 개선:
- Tailwind CSS 클래스를 활용해 오버레이의 위치와 크기를 설정했습니다 (absolute inset-0).
## 결과
- 이제 사용자가 이력서 영역(max-w-4xl) 내부를 클릭하면, 수정 가능한 모든 상호작용(입력, 드래그 등)이 차단됩니다. 대신 클릭 시 경고창이 나타나며, 사용자가 의도적으로 수정 작업을 진행할지 확인할 수 있습니다.


# 세부 변동 사항
- resumepreviewview.vue 파일과 동시에, 메인 "이력서" 기능을 이 파일이 수행하도록 수정.

## 메모장 
### 애로사항이 많았음.

### 읽기 모드로 구현하기 : 
- 이미 데이터가 있는 상태에선 클릭이 안되나, 데이터가 없는 곳은 수정이 되는 불상사
### 새 컴포넌트, 새 뷰 만들어서 아예 새로이 만들기:
- 코드 올 및 원활히 데이터만 가져오지 못함. 시간과 투자가 많이 쓰임
- 새로운 레이아웃 및 디자인 고민에 대한 시간 지체 염려
### 채용한 방법
- resumeview.vue 와 같이 컴포넌트를 import하는 방식을 선택하되
- pdf처럼 보이도록 칸을 할당하고
- 그 위에 투명 레이어로 덮음 -> 하위 컴포넌트의 기능보다 우선시되는 큰 클릭 가능 레이어를 만듦

- 사용자 경험을 침해하지 않고, 수정을 원할 시 route를 통해 기능하도록 구현.
- 기존 구현된 vue 파일의 수정 최소화. 원하는 기능 성공적으로 구현 완료. 


